### PR TITLE
chore(demo): move demo files to demo folder, for github pages uses

### DIFF
--- a/docs/demo-prefixed.html
+++ b/docs/demo-prefixed.html
@@ -12,8 +12,8 @@
     }
   </style>
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
-  <link rel="stylesheet" href="css/flex-prefixed.css">
-  <link rel="stylesheet" href="css/demo-prefixed.css">
+  <link rel="stylesheet" href="../css/flex-prefixed.css">
+  <link rel="stylesheet" href="../css/demo-prefixed.css">
 </head>
 <body>
   <div class="demo-page-content">

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -12,8 +12,8 @@
     }
   </style>
   <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
-  <link rel="stylesheet" href="css/flex.css">
-  <link rel="stylesheet" href="css/demo.css">
+  <link rel="stylesheet" href="../css/flex.css">
+  <link rel="stylesheet" href="../css/demo.css">
 </head>
 <body>
   <div class="demo-page-content">


### PR DESCRIPTION
I find this little library is useful for quick projects, but didn't found documentation right away, need to clone and render file in browser, so if we can serve documentation from github pages, it'll make this library quick to understand and use 